### PR TITLE
20230205 add schema check logic on dbloader constructor

### DIFF
--- a/eureka-sink-postgres/db/src/cursor.rs
+++ b/eureka-sink-postgres/db/src/cursor.rs
@@ -11,7 +11,7 @@ pub trait CursorLoader {
     /// Updates the current state of the `cursors` table, given an `output_module_hash`
     /// value and a [`Cursor`] instance.
     fn update_cursor_query(
-        schema: &String,
+        schema: &str,
         module_hash: String,
         cursor: Cursor,
         conn: &mut PgConnection,
@@ -19,7 +19,7 @@ pub trait CursorLoader {
     /// Writes a new entry to the `cursors` table, given an `output_module_hash` value
     /// and a [`Cursor`] instance.
     fn write_cursor(
-        schema: &String,
+        schema: &str,
         module_hash: String,
         cursor: Cursor,
         conn: &mut PgConnection,
@@ -67,7 +67,7 @@ impl CursorLoader for DBLoader {
     }
 
     fn update_cursor_query(
-        schema: &String,
+        schema: &str,
         module_hash: String,
         cursor: Cursor,
         conn: &mut PgConnection,
@@ -86,7 +86,7 @@ impl CursorLoader for DBLoader {
     }
 
     fn write_cursor(
-        schema: &String,
+        schema: &str,
         module_hash: String,
         cursor: Cursor,
         conn: &mut PgConnection,

--- a/eureka-sink-postgres/db/src/operation.rs
+++ b/eureka-sink-postgres/db/src/operation.rs
@@ -102,15 +102,15 @@ impl Operation {
         query
     }
 
-    pub fn schema_name(&self) -> &String {
+    pub fn schema_name(&self) -> &str {
         &self.schema_name
     }
 
-    pub fn table_name(&self) -> &String {
+    pub fn table_name(&self) -> &str {
         &self.table_name
     }
 
-    pub fn primary_key_column_name(&self) -> &String {
+    pub fn primary_key_column_name(&self) -> &str {
         &self.primary_key_column_name
     }
 

--- a/eureka-sink-postgres/db/src/ops.rs
+++ b/eureka-sink-postgres/db/src/ops.rs
@@ -100,18 +100,18 @@ impl DBLoader {
     /// Gets the the value of a column, with type already parsed in.
     fn get_type(
         &self,
-        table_name: &String,
-        column_name: &String,
+        table_name: &str,
+        column_name: &str,
         value: String,
     ) -> Result<ColumnValue, DBError> {
         let table_cols = self
             .get_tables()
             .get(table_name)
-            .ok_or(DBError::TableNotFound(table_name.clone()))?;
+            .ok_or(DBError::TableNotFound(String::from(table_name)))?;
 
         let col_type = table_cols
             .get(column_name)
-            .ok_or(DBError::ColumnNotFound(column_name.clone()))?;
+            .ok_or(DBError::ColumnNotFound(String::from(column_name)))?;
 
         ColumnValue::parse_type(col_type.clone(), value)
     }
@@ -125,7 +125,7 @@ impl DBLoader {
         data: HashMap<String, ColumnValue>,
     ) -> Operation {
         Operation::new(
-            self.get_schema().clone(),
+            String::from(self.get_schema()),
             table_name.clone(),
             self.get_primary_key_column_name(&table_name)
                 .expect(format!("Primary key column not valid for table: {}", table_name).as_ref()),

--- a/tests/dbloader/src/lib.rs
+++ b/tests/dbloader/src/lib.rs
@@ -41,9 +41,7 @@ fn it_works_load_tables() {
     // assert tables are correctly specified
     let tables = loader.get_available_tables_in_schema();
     assert_eq!(tables.len(), 2);
-    assert!(
-        tables.contains(&String::from("block_meta")) && tables.contains(&String::from("cursors"))
-    );
+    assert!(tables.contains("block_meta") && tables.contains("cursors"));
 
     // assert that column types are correctly specified
     let columns_per_table = loader.get_tables();


### PR DESCRIPTION
Adds logic to execute a simple create schema on DB, if the passed `schema_name` does not exist. Also replaces `&String` with `&str` in the signature of methods.

Warning: very rough, it checks directly on the DB if schema exists. 