### PR TITLE
20230307 specifies the schema in which the cursors table should be created

### DIFF
--- a/eureka-sink-postgres/db/src/db_loader.rs
+++ b/eureka-sink-postgres/db/src/db_loader.rs
@@ -239,8 +239,8 @@ impl DBLoader {
     }
 
     pub fn set_up_cursor_table(&mut self) -> Result<(), DBError> {
-        sql_query(
-            "CREATE TABLE IF NOT EXISTS $1.cursors
+        sql_query(format!(
+            "CREATE TABLE IF NOT EXISTS {}.cursors
 		(
 			id         TEXT NOT NULL CONSTRAINT cursor_pk PRIMARY KEY,
 			cursor     TEXT,
@@ -248,8 +248,8 @@ impl DBLoader {
 			block_id   TEXT
 		);
 	    ",
-        )
-        .bind::<diesel::sql_types::Text, _>(self.get_schema().clone())
+            self.get_schema().clone()
+        ))
         .execute(self.connection())
         .map_err(|e| DBError::DieselError(e))?;
 

--- a/eureka-sink-postgres/db/src/db_loader.rs
+++ b/eureka-sink-postgres/db/src/db_loader.rs
@@ -240,7 +240,7 @@ impl DBLoader {
 
     pub fn set_up_cursor_table(&mut self) -> Result<(), DBError> {
         sql_query(
-            "CREATE TABLE IF NOT EXISTS cursors
+            "CREATE TABLE IF NOT EXISTS $1.cursors
 		(
 			id         TEXT NOT NULL CONSTRAINT cursor_pk PRIMARY KEY,
 			cursor     TEXT,
@@ -249,6 +249,7 @@ impl DBLoader {
 		);
 	    ",
         )
+        .bind::<diesel::sql_types::Text, _>(self.get_schema().clone())
         .execute(self.connection())
         .map_err(|e| DBError::DieselError(e))?;
 


### PR DESCRIPTION
The cursors table query didn't specify the schema under which the cursors would be created, therefore it would always be created under the `public` schema.