### PR TITLE
added support for SF endpoints #77

### DIFF
--- a/substreams-sink/Cargo.toml
+++ b/substreams-sink/Cargo.toml
@@ -7,7 +7,7 @@ description = "Substreams Sink"
 [dependencies]
 prost = { version = "0.11.6" }
 prost-types = "0.11.6"
-tonic = { version = "0.8.3", features = ["gzip"] }
+tonic = { version = "0.8.3", features = ["gzip", "tls-roots"] }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 tokio-stream = { version = "0.1", features = ["net"] }
 anyhow = "1.0"


### PR DESCRIPTION
use [.env.example](https://github.com/eureka-network/eureka-sink-rs/blob/develop/.env.example) and [endpoints](https://substreams.streamingfast.io/reference-and-specs/chains-and-endpoints) for testing